### PR TITLE
feat(blog): cross-link Medium posts + list spacing polish

### DIFF
--- a/app/data/medium-posts.ts
+++ b/app/data/medium-posts.ts
@@ -1,0 +1,45 @@
+export interface MediumPost {
+  title: string
+  url: string
+  date: string
+  description?: string
+  lang?: string
+}
+
+export const mediumPosts: MediumPost[] = [
+  {
+    title: 'A Form, A Pen, and A Prayer',
+    url: 'https://iamlope.medium.com/a-form-a-pen-and-a-prayer-aed96e4b490c',
+    date: '2025-04-28',
+  },
+  {
+    title: 'Love Language',
+    url: 'https://iamlope.medium.com/love-language-11cc15e6160c',
+    date: '2025-02-10',
+  },
+  {
+    title: 'The Lies Imposter Syndrome Tells Us',
+    url: 'https://iamlope.medium.com/the-lies-imposter-syndrome-tells-us-0dc6905b34f0',
+    date: '2025-02-02',
+  },
+  {
+    title: 'Networking: Your Tool for Growth in Tech',
+    url: 'https://iamlope.medium.com/networking-your-tool-for-growth-in-tech-3f3f7dfb1f1b',
+    date: '2025-01-20',
+  },
+  {
+    title: "Chasing the Missing 'n': A Debugger's Odyssey",
+    url: 'https://iamlope.medium.com/chasing-the-missing-n-a-debugger-s-odyssey-5c6412dafdc2',
+    date: '2025-01-16',
+  },
+  {
+    title: "Don't Dry Out",
+    url: 'https://iamlope.medium.com/dont-dry-out-6d988a723c3d',
+    date: '2024-12-22',
+  },
+  {
+    title: 'The Virtual Colony: Why Communication Matters in Remote Teams',
+    url: 'https://iamlope.medium.com/the-virtual-colony-why-communication-matters-in-remote-teams-3928c1c61d3d',
+    date: '2024-12-01',
+  },
+]

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,35 +1,53 @@
 <script setup lang="ts">
 import { ark } from '@ark-ui/vue/factory'
+import { mediumPosts } from '~/data/medium-posts'
+
+const NuxtLink = resolveComponent('NuxtLink')
 
 usePageSeo({
   title: 'Blog — Adebesin Tolulope',
   description: 'Notes on open source, engineering with LLMs, and the projects Lope is building.',
 })
 
-interface BlogPost {
-  path: string
+interface PostItem {
   title: string
-  description?: string
   date: string
+  description?: string
   readingTime?: string
   lang?: string
-  draft?: boolean
+  path?: string
+  external?: string
 }
 
 const { data } = await useAsyncData('blog-list', () =>
   queryCollection('blog')
     .order('date', 'DESC')
-    .all() as Promise<BlogPost[]>,
+    .all() as Promise<(PostItem & { draft?: boolean })[]>,
 )
 
 const grouped = computed(() => {
-  const byYear = new Map<string, BlogPost[]>()
-  for (const post of (data.value ?? []).filter(p => !p.draft)) {
+  const onSite: PostItem[] = (data.value ?? [])
+    .filter(p => !p.draft)
+    .map(({ draft: _draft, ...p }) => p)
+
+  const external: PostItem[] = mediumPosts.map(m => ({
+    title: m.title,
+    date: m.date,
+    description: m.description,
+    lang: m.lang,
+    external: m.url,
+  }))
+
+  const byYear = new Map<string, PostItem[]>()
+  for (const post of [...onSite, ...external]) {
     const year = new Date(post.date).getFullYear().toString()
     if (!byYear.has(year))
       byYear.set(year, [])
     byYear.get(year)!.push(post)
   }
+  for (const posts of byYear.values())
+    posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
   return Array.from(byYear.entries()).sort((a, b) => Number(b[0]) - Number(a[0]))
 })
 
@@ -47,20 +65,21 @@ function fmt(d: string) {
       Notes on open source, engineering with LLMs, and projects I'm building.
     </ark.p>
 
-    <ark.div v-if="!data?.length" class="text-ink-muted text-sm italic">
+    <ark.div v-if="!grouped.length" class="text-ink-muted text-sm italic">
       No posts yet — drafts in flight.
     </ark.div>
 
-    <ark.section v-for="[year, posts] in grouped" :key="year" :id="`y${year}`" :data-toc="year" class="relative scroll-mt-24 mb-10 overflow-hidden md:overflow-visible">
+    <ark.section v-for="[year, posts] in grouped" :key="year" :id="`y${year}`" :data-toc="year" class="relative scroll-mt-24 mb-10 md:min-h-28 overflow-hidden md:overflow-visible">
       <ark.div
         class="absolute top-0 md:-top-6 -start-2 md:-start-14 text-5xl sm:text-7xl md:text-8xl font-700 op-5 select-none pointer-events-none tracking-tight"
       >
         {{ year }}
       </ark.div>
       <ark.ul class="slide-enter-content relative space-y-3 md:space-y-1 pt-10 md:pt-0">
-        <ark.li v-for="post in posts" :key="post.path">
-          <NuxtLink
-            :to="post.path"
+        <ark.li v-for="post in posts" :key="post.external ?? post.path">
+          <component
+            :is="post.external ? 'a' : NuxtLink"
+            v-bind="post.external ? { href: post.external, target: '_blank', rel: 'noopener' } : { to: post.path }"
             class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-1 md:py-2 hover:op-100 op-90 transition-opacity"
           >
             <ark.span
@@ -74,7 +93,13 @@ function fmt(d: string) {
             <ark.span v-if="post.readingTime" class="text-sm text-ink-faint">
               · {{ post.readingTime }}
             </ark.span>
-          </NuxtLink>
+            <ark.span
+              v-if="post.external"
+              class="text-xs text-ink-faint self-start md:self-auto"
+            >
+              Medium ↗
+            </ark.span>
+          </component>
         </ark.li>
       </ark.ul>
     </ark.section>


### PR DESCRIPTION
### 🔗 Linked issue

N/A, no tracking issue.

### 🧭 Context

I wanted my Medium catalog to show up in the blog list without generating on-site pages for those articles, so nothing competes with Medium for SEO. Also fixes a year-watermark spacing glitch on the list.

### 📚 Description

**Medium cross-links.** External articles live in `app/data/medium-posts.ts` and get merged with the on-site posts, then sorted by date within each year. On-site posts render via `NuxtLink`; external ones render as a plain outbound anchor tagged `Medium ↗`. Both are resolved with `resolveComponent` so they work under SSR, and no on-site page is generated for the Medium entries.

**List polish.** Added `md:min-h-28` to each year section so a single-post year no longer collides with the next.

Note: the year-spacing line also lives in #10, so that PR may show a one-line overlap on `index.vue` when it rebases after this merges. Trivial to resolve.
