### PR TITLE
feat(blog): auto reading time + antfu-style list layout

### DIFF
--- a/app/data/medium-posts.ts
+++ b/app/data/medium-posts.ts
@@ -2,6 +2,7 @@ export interface MediumPost {
   title: string
   url: string
   date: string
+  readingTime?: string
   description?: string
   lang?: string
 }
@@ -11,35 +12,42 @@ export const mediumPosts: MediumPost[] = [
     title: 'A Form, A Pen, and A Prayer',
     url: 'https://iamlope.medium.com/a-form-a-pen-and-a-prayer-aed96e4b490c',
     date: '2025-04-28',
+    readingTime: '7min',
   },
   {
     title: 'Love Language',
     url: 'https://iamlope.medium.com/love-language-11cc15e6160c',
     date: '2025-02-10',
+    readingTime: '8min',
   },
   {
     title: 'The Lies Imposter Syndrome Tells Us',
     url: 'https://iamlope.medium.com/the-lies-imposter-syndrome-tells-us-0dc6905b34f0',
     date: '2025-02-02',
+    readingTime: '9min',
   },
   {
     title: 'Networking: Your Tool for Growth in Tech',
     url: 'https://iamlope.medium.com/networking-your-tool-for-growth-in-tech-3f3f7dfb1f1b',
     date: '2025-01-20',
+    readingTime: '5min',
   },
   {
     title: "Chasing the Missing 'n': A Debugger's Odyssey",
     url: 'https://iamlope.medium.com/chasing-the-missing-n-a-debugger-s-odyssey-5c6412dafdc2',
     date: '2025-01-16',
+    readingTime: '4min',
   },
   {
     title: "Don't Dry Out",
     url: 'https://iamlope.medium.com/dont-dry-out-6d988a723c3d',
     date: '2024-12-22',
+    readingTime: '3min',
   },
   {
     title: 'The Virtual Colony: Why Communication Matters in Remote Teams',
     url: 'https://iamlope.medium.com/the-virtual-colony-why-communication-matters-in-remote-teams-3928c1c61d3d',
     date: '2024-12-01',
+    readingTime: '4min',
   },
 ]

--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -15,6 +15,7 @@ if (!post.value)
 const postUrl = computed(() => `https://${host}${route.path}`)
 const shareTitle = computed(() => post.value?.title ?? '')
 const canonicalUrl = computed(() => post.value?.canonical || postUrl.value)
+const readingTime = computed(() => readingTimeText(post.value?.body))
 
 useSeoMeta({
   title: () => (post.value?.title ? `${post.value.title} — Lope` : 'Blog — Lope'),
@@ -91,7 +92,7 @@ function fmt(d?: string) {
       <ark.p class="text-sm text-ink-muted">
         {{ fmt(post.date) }}
         <ark.span v-if="post.duration"> · {{ post.duration }}</ark.span>
-        <ark.span v-else-if="post.readingTime"> · {{ post.readingTime }}</ark.span>
+        <ark.span v-else-if="readingTime"> · {{ readingTime }}</ark.span>
         <template v-if="post.place">
           <ark.span class="text-ink-faint"> · at </ark.span>
           <ark.a

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -12,9 +12,8 @@ usePageSeo({
 interface PostItem {
   title: string
   date: string
-  description?: string
-  readingTime?: string
   lang?: string
+  readingTime?: string
   path?: string
   external?: string
 }
@@ -22,19 +21,25 @@ interface PostItem {
 const { data } = await useAsyncData('blog-list', () =>
   queryCollection('blog')
     .order('date', 'DESC')
-    .all() as Promise<(PostItem & { draft?: boolean })[]>,
+    .all(),
 )
 
 const grouped = computed(() => {
   const onSite: PostItem[] = (data.value ?? [])
     .filter(p => !p.draft)
-    .map(({ draft: _draft, ...p }) => p)
+    .map(p => ({
+      title: p.title,
+      date: p.date,
+      lang: p.lang,
+      readingTime: readingTimeText(p.body),
+      path: p.path,
+    }))
 
   const external: PostItem[] = mediumPosts.map(m => ({
     title: m.title,
     date: m.date,
-    description: m.description,
     lang: m.lang,
+    readingTime: m.readingTime,
     external: m.url,
   }))
 
@@ -75,29 +80,31 @@ function fmt(d: string) {
       >
         {{ year }}
       </ark.div>
-      <ark.ul class="slide-enter-content relative space-y-3 md:space-y-1 pt-10 md:pt-0">
+      <ark.ul class="slide-enter-content relative space-y-4 md:space-y-2 pt-10 md:pt-0">
         <ark.li v-for="post in posts" :key="post.external ?? post.path">
           <component
             :is="post.external ? 'a' : NuxtLink"
             v-bind="post.external ? { href: post.external, target: '_blank', rel: 'noopener' } : { to: post.path }"
-            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-1 md:py-2 hover:op-100 op-90 transition-opacity"
+            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-1 op-90 hover:op-100 transition-opacity"
           >
-            <ark.span
-              v-if="post.lang"
-              class="text-xs bg-ink/10 rounded px-1.5 py-0.5 text-ink-muted self-start"
-            >
-              {{ post.lang }}
+            <ark.span class="flex items-baseline gap-1.5 flex-wrap">
+              <ark.span
+                v-if="post.lang"
+                class="text-xs bg-ink/10 rounded px-1.5 py-0.5 text-ink-muted self-center"
+              >
+                {{ post.lang }}
+              </ark.span>
+              <ark.span class="text-base leading-snug">{{ post.title }}</ark.span>
+              <ark.span
+                v-if="post.external"
+                class="i-lucide-arrow-up-right text-xs text-ink-faint self-center"
+                aria-hidden="true"
+              />
             </ark.span>
-            <ark.span class="text-base">{{ post.title }}</ark.span>
-            <ark.span class="text-sm text-ink-muted">{{ fmt(post.date) }}</ark.span>
-            <ark.span v-if="post.readingTime" class="text-sm text-ink-faint">
-              · {{ post.readingTime }}
-            </ark.span>
-            <ark.span
-              v-if="post.external"
-              class="text-xs text-ink-faint self-start md:self-auto"
-            >
-              Medium ↗
+            <ark.span class="flex items-center gap-1 text-sm text-ink-muted whitespace-nowrap">
+              <ark.span>{{ fmt(post.date) }}</ark.span>
+              <ark.span v-if="post.readingTime" class="text-ink-faint">· {{ post.readingTime }}</ark.span>
+              <ark.span v-if="post.external" class="text-ink-faint">· Medium</ark.span>
             </ark.span>
           </component>
         </ark.li>

--- a/app/utils/reading-time.ts
+++ b/app/utils/reading-time.ts
@@ -1,0 +1,29 @@
+const WORDS_PER_MINUTE = 200
+
+export function readingTimeText(body: unknown): string | undefined {
+  const words = extractText(body).trim().split(/\s+/).filter(Boolean).length
+  if (!words)
+    return undefined
+  return `${Math.max(1, Math.round(words / WORDS_PER_MINUTE))}min`
+}
+
+function extractText(node: unknown): string {
+  if (node == null)
+    return ''
+  if (typeof node === 'string')
+    return node
+  if (Array.isArray(node)) {
+    // MDC element node is [tag, props, ...children]; a node list has arrays at index 0.
+    if (typeof node[0] === 'string')
+      return node.slice(2).map(extractText).join(' ')
+    return node.map(extractText).join(' ')
+  }
+  if (typeof node === 'object') {
+    const obj = node as Record<string, unknown>
+    if ('value' in obj)
+      return extractText(obj.value)
+    if ('children' in obj)
+      return extractText(obj.children)
+  }
+  return ''
+}

--- a/content/blog/being-heard.md
+++ b/content/blog/being-heard.md
@@ -2,7 +2,6 @@
 title: Being Heard Isn't Just About Speaking — It's About Understanding
 description: A guide to internationalization (i18n) in Next.js using next-intl to build multilingual, user-aware web experiences.
 date: 2025-05-26
-readingTime: 6min
 canonical: https://iamlope.medium.com/being-heard-isnt-just-about-speaking-it-s-about-understanding-b700929c5743
 ---
 

--- a/content/blog/nuqs-because-urls-should-do-more.md
+++ b/content/blog/nuqs-because-urls-should-do-more.md
@@ -2,7 +2,6 @@
 title: "Nuqs: Because URLs Should Do More"
 description: Type-safe URL search-param state management in Next.js with nuqs, so user context persists across refreshes and shared links.
 date: 2025-02-17
-readingTime: 7min
 canonical: https://iamlope.medium.com/nuqs-because-urls-should-do-more-5d5d86e873c1
 ---
 

--- a/content/blog/stop-yapping-lock-in.md
+++ b/content/blog/stop-yapping-lock-in.md
@@ -2,7 +2,6 @@
 title: Stop yapping, Lock in
 description: Securing Next.js server actions with next-safe-action — typed input validation, Zod schemas, and clean error handling.
 date: 2025-04-25
-readingTime: 9min
 canonical: https://iamlope.medium.com/stop-yapping-lock-in-5e0a0673ab19
 ---
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A, no tracking issue.

### 🧭 Context

The reading times were hand-typed in each post's frontmatter, so the list and the post page could drift apart, and Medium posts had no read time at all. The mobile list row also stacked awkwardly, with the date, reading time, and Medium tag laid out as separate flat spans.

### 📚 Description

- I added a `readingTimeText()` util that computes reading time from a post's body AST at 200 wpm, and used it in both the list and the post page so they always agree. I removed the manual `readingTime` frontmatter from the on-site posts.
- Medium posts now carry a `readingTime` value derived from their RSS content, so they show a real read time instead of nothing.
- I restructured each list row into two flex groups: a title group (title + inline `↗` for external links) and a meta group (`date · Nmin`, plus `· Medium` for external), so it stacks cleanly as title then meta on mobile.

Note: the list query pulls in post bodies to compute reading time. That's negligible for a handful of posts, but it could move to a build-time step if the list grows.
