### PR TITLE
feat(home): antfu-style inline magic links in the intro

### DIFF
--- a/app/components/MagicLink.vue
+++ b/app/components/MagicLink.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ark } from '@ark-ui/vue/factory'
+
+defineProps<{
+  label: string
+  href?: string
+  to?: string
+  icon?: string
+  logo?: string
+  logoLight?: string
+  color?: string
+}>()
+
+const NuxtLink = resolveComponent('NuxtLink')
+</script>
+
+<template>
+  <component
+    :is="to ? NuxtLink : 'a'"
+    v-bind="to ? { to } : { href, target: '_blank', rel: 'noopener' }"
+    class="magic-link"
+  >
+    <ark.span class="magic-link-icon" aria-hidden="true">
+      <BrandLogo v-if="logo" :src="logo" :light="logoLight" :alt="label" class="w-full h-full" />
+      <ark.span v-else-if="icon" :class="icon" class="w-full! h-full!" :style="color ? { color } : undefined" />
+    </ark.span>
+    <ark.span>{{ label }}</ark.span>
+  </component>
+</template>
+
+<style scoped>
+/* antfu-style inline magic link: favicon/icon + subtle pill, themed via ink tokens. */
+.magic-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  vertical-align: middle;
+  padding: 0.1em 0.4em;
+  margin: 0 0.05em;
+  border-radius: 6px;
+  line-height: 1;
+  text-decoration: none !important;
+  background: rgb(var(--ink) / 0.08);
+  color: rgb(var(--ink) / 0.92) !important;
+  transition: background-color 0.2s, color 0.2s;
+}
+.magic-link:hover {
+  background: rgb(var(--ink) / 0.15);
+  color: rgb(var(--ink)) !important;
+}
+.magic-link-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 1.05em;
+  height: 1.05em;
+  flex: none;
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -82,7 +82,7 @@ const roleRows = [
 
     <ark.p class="text-base text-ink-muted leading-relaxed">
       Hey! I'm Lope, a software engineer and open-source contributor. Founding engineer at
-      <ark.a href="https://www.bethelflow.com/" class="underline op-90 hover:op-100">BethelFlow</ark.a>,
+      <MagicLink href="https://www.bethelflow.com/" label="BethelFlow" logo="/brands/bethelflow.svg" />,
       working across the Chakra and IQ ecosystems.
     </ark.p>
 
@@ -95,15 +95,15 @@ const roleRows = [
 
     <ark.p class="text-base text-ink-muted leading-relaxed">
       I care about open-source sustainability, community growth, and how LLMs are reshaping
-      engineering practice. I write <NuxtLink to="/blog" class="underline">blog posts</NuxtLink> about these,
+      engineering practice. I write <MagicLink to="/blog" label="blog posts" icon="i-lucide-newspaper" /> about these,
       ship side-projects on the side, and maintain a few small tools I rely on every day.
     </ark.p>
 
     <ark.p class="text-base text-ink-muted leading-relaxed">
       You can find my work on
-      <ark.a href="https://github.com/Adebesin-Cell" class="underline">GitHub</ark.a>,
-      reach me on <ark.a href="https://www.linkedin.com/in/adebesin-tolulope/" class="underline">LinkedIn</ark.a>,
-      or browse my <NuxtLink to="/projects" class="underline">projects</NuxtLink>.
+      <MagicLink href="https://github.com/Adebesin-Cell" label="GitHub" icon="i-simple-icons-github" />,
+      reach me on <MagicLink href="https://www.linkedin.com/in/adebesin-tolulope/" label="LinkedIn" icon="i-simple-icons-linkedin" color="#0A66C2" />,
+      or browse my <MagicLink to="/projects" label="projects" icon="i-lucide-folder-git-2" />.
     </ark.p>
   </ark.article>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

N/A, no tracking issue.

### 🧭 Context

The inline links in the homepage intro were plain underlines, which looked disconnected from the favicon/icon chips in the role row right above them. I wanted the intro to feel cohesive with the rest of that section.

### 📚 Description

I added a `MagicLink` component that renders an inline link as a small favicon (via `BrandLogo`) or iconify icon plus a label in a subtle pill, themed with the `--ink` tokens so it adapts to light and dark. It handles both internal (`to`) and external (`href`) links. I swapped the five intro links (BethelFlow, blog posts, GitHub, LinkedIn, projects) over to it. No new dependencies: it's a plain auto-imported Vue component, since the homepage is `.vue` rather than markdown.
