### PR TITLE
feat(blog+essays): flat blog list + dedicated Essays page

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -3,6 +3,7 @@ import { ark } from '@ark-ui/vue/factory'
 
 const links = [
   { to: '/blog', label: 'Blog', icon: 'i-lucide-pencil-line' },
+  { to: '/essays', label: 'Essays', icon: 'i-lucide-feather' },
   { to: '/projects', label: 'Projects', icon: 'i-lucide-folder-git-2' },
   { to: '/talks', label: 'Talks', icon: 'i-lucide-mic' },
   { to: '/releases', label: 'Releases', icon: 'i-lucide-git-merge' },

--- a/app/data/substack-posts.ts
+++ b/app/data/substack-posts.ts
@@ -1,0 +1,50 @@
+export interface SubstackPost {
+  title: string
+  url: string
+  date: string
+}
+
+export const substackUrl = 'https://iamlope.substack.com'
+
+export const substackPosts: SubstackPost[] = [
+  {
+    title: 'Wow, Have You Tried Just Being Better?',
+    url: 'https://iamlope.substack.com/p/wow-have-you-tried-just-being-better',
+    date: '2026-04-26',
+  },
+  {
+    title: 'When Sakura Blooms',
+    url: 'https://iamlope.substack.com/p/when-sakura-blooms',
+    date: '2026-02-14',
+  },
+  {
+    title: 'Effort, Death, and Love',
+    url: 'https://iamlope.substack.com/p/effort-death-and-love',
+    date: '2026-01-31',
+  },
+  {
+    title: 'A Multitude of Good and a Bad Day',
+    url: 'https://iamlope.substack.com/p/a-multitude-of-good-and-a-bad-day',
+    date: '2026-01-28',
+  },
+  {
+    title: 'The Mercy No One Asks For',
+    url: 'https://iamlope.substack.com/p/the-mercy-no-one-asks-for',
+    date: '2026-01-28',
+  },
+  {
+    title: 'The Cost No One Wants to See',
+    url: 'https://iamlope.substack.com/p/the-cost-no-one-wants-to-see',
+    date: '2026-01-26',
+  },
+  {
+    title: 'The Illusion of Taste',
+    url: 'https://iamlope.substack.com/p/the-illusion-of-taste',
+    date: '2026-01-25',
+  },
+  {
+    title: 'The Will of the Weak',
+    url: 'https://iamlope.substack.com/p/the-will-of-the-weak',
+    date: '2026-01-25',
+  },
+]

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ark } from '@ark-ui/vue/factory'
 import { mediumPosts } from '~/data/medium-posts'
+import { substackPosts, substackUrl } from '~/data/substack-posts'
 
 const NuxtLink = resolveComponent('NuxtLink')
 
@@ -24,7 +25,7 @@ const { data } = await useAsyncData('blog-list', () =>
     .all(),
 )
 
-const grouped = computed(() => {
+const posts = computed<PostItem[]>(() => {
   const onSite: PostItem[] = (data.value ?? [])
     .filter(p => !p.draft)
     .map(p => ({
@@ -43,18 +44,12 @@ const grouped = computed(() => {
     external: m.url,
   }))
 
-  const byYear = new Map<string, PostItem[]>()
-  for (const post of [...onSite, ...external]) {
-    const year = new Date(post.date).getFullYear().toString()
-    if (!byYear.has(year))
-      byYear.set(year, [])
-    byYear.get(year)!.push(post)
-  }
-  for (const posts of byYear.values())
-    posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-
-  return Array.from(byYear.entries()).sort((a, b) => Number(b[0]) - Number(a[0]))
+  return [...onSite, ...external].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 })
+
+function year(d: string) {
+  return new Date(d).getFullYear()
+}
 
 function fmt(d: string) {
   return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
@@ -66,26 +61,32 @@ function fmt(d: string) {
     <ark.h1 class="text-4xl font-700 tracking-tight mb-3">
       Blog
     </ark.h1>
-    <ark.p class="text-ink-muted mb-12">
+    <ark.p class="text-ink-muted mb-10">
       Notes on open source, engineering with LLMs, and projects I'm building.
     </ark.p>
 
-    <ark.div v-if="!grouped.length" class="text-ink-muted text-sm italic">
+    <ark.div v-if="!posts.length" class="text-ink-muted text-sm italic">
       No posts yet — drafts in flight.
     </ark.div>
 
-    <ark.section v-for="[year, posts] in grouped" :key="year" :id="`y${year}`" :data-toc="year" class="relative scroll-mt-24 mb-10 md:min-h-28 overflow-hidden md:overflow-visible">
-      <ark.div
-        class="absolute top-0 md:-top-6 -start-2 md:-start-14 text-5xl sm:text-7xl md:text-8xl font-700 op-5 select-none pointer-events-none tracking-tight"
-      >
-        {{ year }}
-      </ark.div>
-      <ark.ul class="slide-enter-content relative space-y-4 md:space-y-2 pt-10 md:pt-0">
-        <ark.li v-for="post in posts" :key="post.external ?? post.path">
+    <ark.ul class="relative">
+      <template v-for="(post, idx) in posts" :key="post.external ?? post.path">
+        <ark.li
+          v-if="idx === 0 || year(post.date) !== year(posts[idx - 1].date)"
+          :id="`y${year(post.date)}`"
+          :data-toc="year(post.date)"
+          class="relative select-none pointer-events-none scroll-mt-24 h-16 md:h-20 mt-10 first:mt-2"
+          aria-hidden="true"
+        >
+          <ark.span class="absolute -top-2 md:-top-4 -start-1 md:-start-3 text-6xl sm:text-7xl md:text-8xl font-700 op-5 tracking-tight leading-none">
+            {{ year(post.date) }}
+          </ark.span>
+        </ark.li>
+        <ark.li class="slide-enter-content relative">
           <component
             :is="post.external ? 'a' : NuxtLink"
             v-bind="post.external ? { href: post.external, target: '_blank', rel: 'noopener' } : { to: post.path }"
-            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-1 op-90 hover:op-100 transition-opacity"
+            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-2 op-90 hover:op-100 transition-opacity"
           >
             <ark.span class="flex items-baseline gap-1.5 flex-wrap">
               <ark.span
@@ -104,9 +105,41 @@ function fmt(d: string) {
             <ark.span class="flex items-center gap-1 text-sm text-ink-muted whitespace-nowrap">
               <ark.span>{{ fmt(post.date) }}</ark.span>
               <ark.span v-if="post.readingTime" class="text-ink-faint">· {{ post.readingTime }}</ark.span>
-              <ark.span v-if="post.external" class="text-ink-faint">· Medium</ark.span>
             </ark.span>
           </component>
+        </ark.li>
+      </template>
+    </ark.ul>
+
+    <ark.section class="mt-14 pt-8 border-t border-ink/10">
+      <ark.div class="flex items-baseline justify-between gap-4 flex-wrap mb-3">
+        <ark.h2 class="text-lg font-600">
+          From the newsletter
+        </ark.h2>
+        <ark.a
+          :href="substackUrl"
+          target="_blank"
+          rel="noopener"
+          class="inline-flex items-center gap-1 text-sm text-ink-muted hover:text-ink transition-colors"
+        >
+          Read on Substack
+          <ark.span class="i-lucide-arrow-up-right text-xs" aria-hidden="true" />
+        </ark.a>
+      </ark.div>
+      <ark.p class="text-sm text-ink-muted mb-5 max-w-prose">
+        Beyond code, I write more personal essays — on effort, taste, and being human.
+      </ark.p>
+      <ark.ul class="space-y-2">
+        <ark.li v-for="post in substackPosts.slice(0, 5)" :key="post.url">
+          <ark.a
+            :href="post.url"
+            target="_blank"
+            rel="noopener"
+            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 op-90 hover:op-100 transition-opacity"
+          >
+            <ark.span class="text-base leading-snug">{{ post.title }}</ark.span>
+            <ark.span class="text-sm text-ink-faint whitespace-nowrap">{{ fmt(post.date) }}</ark.span>
+          </ark.a>
         </ark.li>
       </ark.ul>
     </ark.section>

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ark } from '@ark-ui/vue/factory'
 import { mediumPosts } from '~/data/medium-posts'
-import { substackPosts, substackUrl } from '~/data/substack-posts'
 
 const NuxtLink = resolveComponent('NuxtLink')
 
@@ -110,38 +109,5 @@ function fmt(d: string) {
         </ark.li>
       </template>
     </ark.ul>
-
-    <ark.section class="mt-14 pt-8 border-t border-ink/10">
-      <ark.div class="flex items-baseline justify-between gap-4 flex-wrap mb-3">
-        <ark.h2 class="text-lg font-600">
-          From the newsletter
-        </ark.h2>
-        <ark.a
-          :href="substackUrl"
-          target="_blank"
-          rel="noopener"
-          class="inline-flex items-center gap-1 text-sm text-ink-muted hover:text-ink transition-colors"
-        >
-          Read on Substack
-          <ark.span class="i-lucide-arrow-up-right text-xs" aria-hidden="true" />
-        </ark.a>
-      </ark.div>
-      <ark.p class="text-sm text-ink-muted mb-5 max-w-prose">
-        Beyond code, I write more personal essays — on effort, taste, and being human.
-      </ark.p>
-      <ark.ul class="space-y-2">
-        <ark.li v-for="post in substackPosts.slice(0, 5)" :key="post.url">
-          <ark.a
-            :href="post.url"
-            target="_blank"
-            rel="noopener"
-            class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 op-90 hover:op-100 transition-opacity"
-          >
-            <ark.span class="text-base leading-snug">{{ post.title }}</ark.span>
-            <ark.span class="text-sm text-ink-faint whitespace-nowrap">{{ fmt(post.date) }}</ark.span>
-          </ark.a>
-        </ark.li>
-      </ark.ul>
-    </ark.section>
   </ark.article>
 </template>

--- a/app/pages/essays.vue
+++ b/app/pages/essays.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ark } from '@ark-ui/vue/factory'
+import { substackPosts, substackUrl } from '~/data/substack-posts'
+
+usePageSeo({
+  title: 'Essays — Adebesin Tolulope',
+  description: 'Personal essays on effort, taste, and being human — from my Substack.',
+})
+
+function fmt(d: string) {
+  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+</script>
+
+<template>
+  <ark.article class="slide-enter-content">
+    <ark.h1 class="text-4xl font-700 tracking-tight mb-3">
+      Essays
+    </ark.h1>
+    <ark.p class="text-ink-muted mb-10 max-w-prose">
+      Beyond code — personal essays on effort, taste, and being human. Published on
+      <ark.a
+        :href="substackUrl"
+        target="_blank"
+        rel="noopener"
+        class="underline hover:text-ink transition-colors"
+      >
+        Substack
+      </ark.a>.
+    </ark.p>
+
+    <ark.ul class="space-y-4 md:space-y-2">
+      <ark.li v-for="post in substackPosts" :key="post.url">
+        <ark.a
+          :href="post.url"
+          target="_blank"
+          rel="noopener"
+          class="flex flex-col md:flex-row md:items-baseline gap-0.5 md:gap-3 py-1 op-90 hover:op-100 transition-opacity"
+        >
+          <ark.span class="flex items-baseline gap-1.5">
+            <ark.span class="text-base leading-snug">{{ post.title }}</ark.span>
+            <ark.span class="i-lucide-arrow-up-right text-xs text-ink-faint self-center" aria-hidden="true" />
+          </ark.span>
+          <ark.span class="text-sm text-ink-muted whitespace-nowrap">{{ fmt(post.date) }}</ark.span>
+        </ark.a>
+      </ark.li>
+    </ark.ul>
+  </ark.article>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

N/A, no tracking issue.

### 🧭 Context

The per-year sections on `/blog` used a `min-height` hack that left the year watermark overlapping the first post and a dead gap at the end. I also wanted the personal Substack essays to have their own home rather than mixing genres into the technical blog.

### 📚 Description

- I reworked `/blog` into a flat list with a year "spacer" marker between years instead of per-year sections, which fixes the watermark overlap and the trailing gap. The markers keep their `id` and `data-toc` so the TOC year-jump still works. I also dropped the `· Medium` text since the `↗` icon already signals an external link.
- I added a new `/essays` page that lists the Substack essays from a new `app/data/substack-posts.ts` (8 posts, each linking out), plus a link to the Substack itself.
- I added Essays to the nav via the shared `links` array, so it shows on both desktop and mobile.
