### PR TITLE
fix(essays): honest page copy

### DIFF
--- a/app/pages/essays.vue
+++ b/app/pages/essays.vue
@@ -4,7 +4,7 @@ import { substackPosts, substackUrl } from '~/data/substack-posts'
 
 usePageSeo({
   title: 'Essays — Adebesin Tolulope',
-  description: 'Personal essays on effort, taste, and being human — from my Substack.',
+  description: 'Away from code, I try to write. Just write, and perhaps share what I think. Personal essays on Substack.',
 })
 
 function fmt(d: string) {
@@ -18,7 +18,7 @@ function fmt(d: string) {
       Essays
     </ark.h1>
     <ark.p class="text-ink-muted mb-10 max-w-prose">
-      Beyond code — personal essays on effort, taste, and being human. Published on
+      Away from code, I try to write. Just write, and perhaps share what I think. It lives on
       <ark.a
         :href="substackUrl"
         target="_blank"


### PR DESCRIPTION
### 🔗 Linked issue

N/A. No tracking issue.

### 🧭 Context

The /essays copy was written from the post titles rather than the actual writing. It claimed a curated theme ("effort, taste, and being human") that didn't really reflect what the essays are.

### 📚 Description

I rewrote the copy in my own framing: away from code, a place to just write and share what I think. I updated both the visible intro line and the SEO `description` in `app/pages/essays.vue`.
