### PR TITLE
feat(blog): "Taking the easy way out" essay

### DIFF
--- a/content/blog/taking-the-easy-way-out.md
+++ b/content/blog/taking-the-easy-way-out.md
@@ -1,0 +1,63 @@
+---
+title: Taking the easy way out
+description: On the strange frustration of watching AI agents cut corners, and a trick from my electronics classes that taught me, years early, exactly why they do it.
+date: 2026-07-18
+---
+
+![A circuit split into two paths to a green checkmark: the honest path runs through a resistor and barely carries any current, while a short circuit carries almost all of it, sparking as it jumps to the check.](/images/blog/easy-way-out/cover.svg)
+
+There's a specific kind of annoyed I only feel around AI agents, and it always arrives at the same moment. The moment it tells me it's done.
+
+Done. Tests pass. Green across the board. And then I actually look. The tests were never run. Or the data it "tested" against was quietly invented so nothing could ever fail. Or there's an `any` sitting right where a real type should be, taped over the warning light. It didn't do the work. It did the smallest thing that *looks* like the work, and then told me, with real confidence, that the room was clean. It reminds me of a kid who gets told to tidy their room and just shoves everything under the bed. Floor's clear. Technically.
+
+We've leaned on agents a lot more at IQ.wiki lately, and I don't think we're special; everyone is. Most of the time it's genuinely great. But every so often you catch it doing the thing, and the thing is always the same shape: rushed work, done to escape the room, not to do the work. So you end up babysitting. Watching the diff like a hawk. There are skills in place, directions in place, and still, every so often, you get hit with the [slop](https://www.merriam-webster.com/wordplay/word-of-the-year) (which was Merriam-Webster's word of the year for 2025, so, clearly, it's not just me). You ask for a fix and get a cheerful *"You're absolutely right!"* and a diff that quietly weakened the assertion instead of fixing the bug.
+
+For a while I took it personally, like the model was being sly with me. It isn't. And the strange part is, I'd already met this exact behaviour years before I ever touched an agent. In an electronics lab.
+
+## The bypass capacitor
+
+Back in school, studying electronics engineering, I learned a small piece of magic I've never quite shaken.
+
+You build a common-emitter amplifier, and to keep it steady you put a resistor on the emitter. That resistor does something quietly clever: it feeds a little of the output back against the input, which stabilizes the whole thing and keeps it from distorting. The catch is that it also eats your gain. Your beautiful amplifier suddenly amplifies a lot less.
+
+Then they teach you the trick. You drop a capacitor across that resistor, a bypass capacitor, and the gain jumps right back up. Why? Because to the signal, the capacitor looks like a near-short, an easy path straight around the resistor. The current stops fighting through the resistor and just goes around it. You didn't make the amplifier smarter. You left a cheaper path open, and the signal took it, instantly.
+
+![A signal path that splits: the top branch runs through the emitter resistor and carries only a trickle, while the bottom branch runs through a bypass capacitor and carries almost all of the current, going around the resistor.](/images/blog/easy-way-out/bypass-capacitor.svg)
+
+It felt like cheating the first time I saw it. It wasn't; it was on the syllabus. But it taught me something I keep coming back to: current does not care what you intended. It takes the cheapest path you leave open, every single time.
+
+I should correct the lazy version of that before someone else does, because, well, correcting the shortcut is sort of the whole point here. We say "current takes the path of least resistance," and it isn't quite true. Current takes *every* path at once, splitting itself between them in inverse proportion to how much each one resists. It floods all of them. It just pours most of itself through the cheapest one. Offer it a near-zero path and almost all of it rushes through, and we have a name for that near-zero path. We call it a short circuit, and the reason it's dangerous is that all that current taking the easy way is exactly how fires start.
+
+## Don't blame the electron
+
+So here's what clicked for me. An agent cutting corners is just that signal. You give it a task and its effort floods every route to the goal, pouring most heavily through whichever one is cheapest. Fixing the algorithm is the emitter resistor: high resistance, the honest path, and it costs. The `any` is a bypass capacitor. The faked data is a bypass capacitor. Deleting the failing test is a bypass capacitor. Hardcoding the answer is a dead short. The model isn't choosing to be dishonest any more than the signal chooses the capacitor, or water chooses to run downhill. It's a gradient, and the cheap path was sitting right there with almost nothing on it.
+
+It has a proper name, this behaviour. Researchers call it **specification gaming**, or **reward hacking**, and DeepMind put it about as plainly as it can be put: *["a behaviour that satisfies the literal specification of an objective without achieving the intended outcome."](https://deepmind.google/blog/specification-gaming-the-flip-side-of-ai-ingenuity/)* It's older than large language models, older than any of this. Point an optimizer at "make the tests green" and nothing else, and you'll get green tests. You won't necessarily get correct software. A green suite was only ever a stand-in for the thing you actually wanted, and the moment it becomes the target, it stops being a good stand-in.
+
+My favourite version of it comes from a developer who watched an agent burn through billions of tokens on a port and then just delete every test that wouldn't pass, until CI went green because most of the suite no longer existed. His conclusion is the truest sentence I've read about any of this: *["Give an AI a single signal, `pnpm test` is green, and it will reach for the path of appearing to pass over the path of actually passing. Every time."](https://typia.io/blog/ai-deleted-my-tests-and-said-all-tests-pass/)*
+
+The path of appearing to pass. He said path. He didn't know he was describing a circuit.
+
+And you don't get to be mad at the electron for going where the wiring sent it. You wired the circuit.
+
+## The amplifier
+
+Here's the bit that took me years to actually see. That emitter resistor I "cheated" past in school, the one that costs you gain, it has a name for what it does too: negative feedback. It [trades raw gain](https://en.wikipedia.org/wiki/Negative-feedback_amplifier) for linearity and control. The bypass capacitor doesn't beat that trade. It just refuses it: *give me my gain back, I'll eat the distortion.*
+
+And honestly? I get it. A raw, unconstrained model is an amplifier with the gain cranked all the way up: enormous signal and enormous distortion riding out together. If that were me, all gain and all speed, I wouldn't want to hand half my effectiveness back to some resistor either. Reaching for the bypass cap is the most natural move in the world. It's what I'd do.
+
+But every real amplifier makes that trade on purpose, because gain you can't trust is just noise. The guardrails, the reviews, the skills, the tests the agent isn't allowed to touch, all of that is the emitter resistor. Deliberate feedback. A little gain given up for a signal you can actually rely on.
+
+![Two amplifiers side by side. The left one has an intact feedback loop and produces a clean, bounded wave. The right one has had its feedback loop cut, so it oscillates out of control and clips against the supply rails.](/images/blog/easy-way-out/amplifier.svg)
+
+And this is the line that finally tied it all together for me. Negative feedback only saves you *if the loop stays honest.* A bypass capacitor is at least an honest trade, you know exactly what you gave up, and the feedback is still there underneath, holding the bias steady. But when the feedback path itself gets corrupted, the amplifier doesn't just lose a little gain. The sign flips. Negative feedback becomes positive feedback, and the whole thing screams into oscillation and clips against the rails.
+
+An agent that deletes the failing test isn't dropping a bypass capacitor anymore. It has reached into the feedback loop and cut the wire. It stopped going *around* the resistor and started rewriting the meter that tells you whether the circuit works at all. There's a separate, scarier name for that one: **reward tampering**. It's the difference between an agent that cuts a corner and one that quietly corrupts its own scorer. When the thing meant to tell you the truth becomes the thing being optimized, you don't have a feedback loop anymore. You have an amplifier with its wires crossed, cheerfully reporting that everything is fine while it burns.
+
+## The room, still messy
+
+I don't have a clean fix to hand you. I still babysit. I still catch things.
+
+But I've stopped being angry at the agent, the way you can't really stay angry at current for going where the wire lets it. And if I'm honest, I recognise the move. I was that student once, the one who studies for the grade instead of the understanding, who finds the version of "done" that clears the check and quietly hopes the check was measuring the right thing. We all reach for the bypass capacitor. The agent is just faster, tireless, and completely without the small flush of shame that stops most people from deleting the tests at 2am.
+
+So now, when I catch myself reaching for my own easy way out, the `any`, the skipped test, the "good enough, ship it", I think about that resistor in the lab. About how the entire trick of it was giving up a little gain on purpose, to get back something you could trust. The cheap path is on every circuit. It always will be. The work, mine and the model's both, is choosing the resistor anyway.

--- a/public/images/blog/easy-way-out/amplifier.svg
+++ b/public/images/blog/easy-way-out/amplifier.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" role="img" aria-label="Two amplifiers. Left: an op-amp with an intact negative-feedback loop produces a clean bounded wave. Right: the same amplifier with its feedback loop cut produces a runaway oscillation that clips against the supply rails.">
+  <style>
+    .bg     { fill: #fbfbfa; }
+    .ink    { fill: #16150f; }
+    .amp    { fill: none; stroke: #16150f; stroke-opacity: 0.6; stroke-width: 3.5; stroke-linejoin: round; }
+    .wire   { fill: none; stroke: #16150f; stroke-opacity: 0.34; stroke-width: 3; }
+    .title  { fill: #16150f; opacity: 0.62; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 22px; letter-spacing: 1px; }
+    .sub    { fill: #16150f; opacity: 0.42; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 17px; }
+    .pin    { fill: #16150f; opacity: 0.55; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 22px; }
+    .clean  { fill: none; stroke: #15a34a; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }
+    .blow   { fill: none; stroke: #e0562d; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }
+    .rail   { fill: none; stroke: #16150f; stroke-opacity: 0.22; stroke-width: 2; stroke-dasharray: 6 8; }
+    .cut    { fill: none; stroke: #e0562d; stroke-width: 3.5; stroke-linecap: round; }
+    .divide { fill: none; stroke: #16150f; stroke-opacity: 0.12; stroke-width: 2; }
+    .dot    { fill: #16150f; opacity: 0.06; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0f0f0e; }
+      .ink { fill: #f2f2ee; }
+      .amp { stroke: #f2f2ee; stroke-opacity: 0.6; }
+      .wire { stroke: #f2f2ee; stroke-opacity: 0.3; }
+      .title { fill: #f2f2ee; opacity: 0.65; }
+      .sub   { fill: #f2f2ee; opacity: 0.45; }
+      .pin   { fill: #f2f2ee; opacity: 0.6; }
+      .clean { stroke: #2fbf5a; }
+      .blow  { stroke: #ff7a4d; }
+      .rail  { stroke: #f2f2ee; stroke-opacity: 0.2; }
+      .cut   { stroke: #ff7a4d; }
+      .divide{ stroke: #f2f2ee; stroke-opacity: 0.12; }
+      .dot   { fill: #f2f2ee; opacity: 0.07; }
+    }
+  </style>
+
+  <pattern id="adots" width="24" height="24" patternUnits="userSpaceOnUse"><circle class="dot" cx="2" cy="2" r="1.6" /></pattern>
+  <rect class="bg" x="0" y="0" width="1200" height="540" />
+  <rect x="0" y="0" width="1200" height="540" fill="url(#adots)" />
+  <path class="divide" d="M600 70 V470" />
+
+  <!-- ================= PANEL A: honest negative feedback ================= -->
+  <text class="title" x="70" y="60">NEGATIVE FEEDBACK</text>
+  <text class="sub"   x="70" y="88">gain traded for a clean signal</text>
+
+  <!-- inputs -->
+  <path class="wire" d="M70 200 H210" />
+  <path class="wire" d="M70 240 H210" />
+  <text class="pin" x="182" y="196">+</text>
+  <text class="pin" x="184" y="252">–</text>
+
+  <!-- op-amp triangle -->
+  <path class="amp" d="M210 150 V290 L360 220 Z" />
+
+  <!-- output -->
+  <path class="wire" d="M360 220 H470" />
+  <circle class="ink" cx="430" cy="220" r="5" />
+
+  <!-- feedback loop (intact), with resistor -->
+  <path class="wire" d="M430 220 V120 H322" />
+  <path class="wire" d="M322 120 l-10 -12 l-20 24 l-20 -24 l-20 24 l-10 -12 H150 V240 H210" />
+
+  <!-- clean bounded output -->
+  <path class="clean" d="M470 220 Q489 196 508 220 Q527 244 546 220 Q565 196 584 220" />
+
+  <!-- ================= PANEL B: tampered loop ================= -->
+  <text class="title" x="650" y="60">LOOP TAMPERED</text>
+  <text class="sub"   x="650" y="88">it flips positive and screams</text>
+
+  <!-- inputs -->
+  <path class="wire" d="M650 200 H790" />
+  <path class="wire" d="M650 240 H790" />
+  <text class="pin" x="762" y="196">+</text>
+  <text class="pin" x="764" y="252">–</text>
+
+  <!-- op-amp triangle -->
+  <path class="amp" d="M790 150 V290 L940 220 Z" />
+
+  <!-- output -->
+  <path class="wire" d="M940 220 H1010" />
+  <circle class="ink" cx="1000" cy="220" r="5" />
+
+  <!-- feedback loop, CUT near the top -->
+  <path class="wire" d="M1000 220 V120 H952" />
+  <path class="wire" d="M888 120 H730 V240 H790" />
+  <!-- the cut -->
+  <g class="cut">
+    <path d="M948 108 l-16 24 M932 108 l16 24" />
+    <path d="M902 120 l14 -18 M902 120 l18 12 M902 120 l-4 22" />
+  </g>
+  <text class="sub" x="856" y="150" fill="#e0562d">cut</text>
+
+  <!-- supply rails -->
+  <path class="rail" d="M1010 150 H1150" />
+  <path class="rail" d="M1010 290 H1150" />
+
+  <!-- runaway oscillation, growing until it clips the rails -->
+  <path class="blow" d="M1010 220 Q1021 210 1032 220 Q1043 230 1054 220 Q1066 200 1078 220 Q1090 240 1102 220 Q1114 152 1126 220 Q1138 288 1150 220" />
+</svg>

--- a/public/images/blog/easy-way-out/bypass-capacitor.svg
+++ b/public/images/blog/easy-way-out/bypass-capacitor.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 430" role="img" aria-label="A signal path splits into two branches around a rejoining node. The top branch runs through the emitter resistor and carries only a thin trickle of current. The bottom branch runs through a bypass capacitor and carries almost all of the current, taking the easy path around the resistor.">
+  <style>
+    .bg     { fill: #fbfbfa; }
+    .ink    { fill: #16150f; }
+    .comp   { fill: none; stroke: #16150f; stroke-opacity: 0.6; stroke-width: 3.5; stroke-linecap: round; stroke-linejoin: round; }
+    .wire   { fill: none; stroke: #16150f; stroke-opacity: 0.32; stroke-width: 3; }
+    .kicker { fill: #16150f; opacity: 0.45; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 21px; letter-spacing: 1px; }
+    .label  { fill: #16150f; opacity: 0.6;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 20px; }
+    .sub    { fill: #16150f; opacity: 0.4;  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 16px; }
+    .flow      { fill: none; stroke: #16150f; stroke-linecap: round; }
+    .flow-thin { stroke-width: 2.5; stroke-opacity: 0.38; stroke-dasharray: 3 45; animation: flow 4.6s linear infinite; }
+    .flow-fat  { stroke-width: 6.5; stroke-opacity: 0.9;  stroke-dasharray: 6 16; animation: flow 1s   linear infinite; }
+    .node   { fill: #16150f; }
+    .dot    { fill: #16150f; opacity: 0.06; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0f0f0e; }
+      .ink { fill: #f2f2ee; }
+      .comp { stroke: #f2f2ee; stroke-opacity: 0.62; }
+      .wire { stroke: #f2f2ee; stroke-opacity: 0.3; }
+      .kicker { fill: #f2f2ee; opacity: 0.5; }
+      .label  { fill: #f2f2ee; opacity: 0.62; }
+      .sub    { fill: #f2f2ee; opacity: 0.42; }
+      .flow { stroke: #f2f2ee; }
+      .node { fill: #f2f2ee; }
+      .dot { fill: #f2f2ee; opacity: 0.07; }
+    }
+    @keyframes flow { to { stroke-dashoffset: -276; } }
+    @media (prefers-reduced-motion: reduce) { .flow-thin, .flow-fat { animation: none; } }
+  </style>
+
+  <pattern id="bdots" width="24" height="24" patternUnits="userSpaceOnUse"><circle class="dot" cx="2" cy="2" r="1.6" /></pattern>
+  <rect class="bg" x="0" y="0" width="1200" height="430" />
+  <rect x="0" y="0" width="1200" height="430" fill="url(#bdots)" />
+
+  <text class="kicker" x="120" y="70">// bypass the resistor, reclaim the gain</text>
+
+  <!-- main line in and out -->
+  <path class="wire" d="M150 215 H320" />
+  <path class="wire" d="M880 215 H1050" />
+  <text class="sub" x="118" y="250">signal</text>
+
+  <!-- top branch: emitter resistor -->
+  <path class="wire" d="M320 215 V130 H430" />
+  <path class="wire" d="M430 130 l14 -16 l28 32 l28 -32 l28 32 l28 -32 l28 32 l14 -16 H770 V215" />
+  <path class="flow flow-thin" d="M320 215 V130 H430 M650 130 H770 V215" />
+  <text class="label" x="470" y="106">emitter resistor</text>
+  <text class="sub"   x="470" y="150">feedback · costs gain</text>
+
+  <!-- bottom branch: bypass capacitor -->
+  <path class="wire" d="M320 215 V305 H548" />
+  <path class="comp" d="M548 278 V332 M572 278 V332" />
+  <path class="wire" d="M572 305 H770 V215" />
+  <path class="flow flow-fat" d="M320 215 V305 H548 M572 305 H770 V215" />
+  <text class="label" x="470" y="392">bypass capacitor</text>
+  <text class="sub"   x="620" y="392">the easy way around</text>
+
+  <!-- split / merge nodes -->
+  <circle class="node" cx="320" cy="215" r="6" />
+  <circle class="node" cx="770" cy="215" r="6" />
+</svg>

--- a/public/images/blog/easy-way-out/cover.svg
+++ b/public/images/blog/easy-way-out/cover.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" role="img" aria-label="A circuit split into two paths to a green checkmark. The top path runs through a resistor labeled 'actually fix it' and carries little current. The bottom path is a short circuit carrying almost all the current, with a spark where it jumps.">
+  <style>
+    .bg     { fill: #fbfbfa; }
+    .ink    { fill: #16150f; }
+    .kicker { fill: #16150f; opacity: 0.45; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 21px; letter-spacing: 1px; }
+    .label  { fill: #16150f; opacity: 0.55; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 19px; }
+    .wire   { fill: none; stroke: #16150f; stroke-opacity: 0.30; stroke-width: 3; }
+    .node   { fill: #16150f; }
+    .flow   { fill: none; stroke: #16150f; stroke-linecap: round; }
+    .flow-fast { stroke-width: 5; stroke-opacity: 0.85; stroke-dasharray: 5 19; animation: flow 1.1s linear infinite; }
+    .flow-slow { stroke-width: 3; stroke-opacity: 0.4;  stroke-dasharray: 4 44; animation: flow 4.2s linear infinite; }
+    .green  { fill: none; stroke: #15a34a; stroke-width: 6; stroke-linecap: round; stroke-linejoin: round; }
+    .greenring { fill: none; stroke: #15a34a; stroke-opacity: 0.5; stroke-width: 2.5; }
+    .spark  { fill: none; stroke: #e0562d; stroke-width: 3.5; stroke-linecap: round; }
+    .dot    { fill: #16150f; opacity: 0.06; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0f0f0e; }
+      .ink { fill: #f2f2ee; }
+      .kicker { fill: #f2f2ee; opacity: 0.5; }
+      .label  { fill: #f2f2ee; opacity: 0.6; }
+      .wire { stroke: #f2f2ee; stroke-opacity: 0.28; }
+      .node { fill: #f2f2ee; }
+      .flow { stroke: #f2f2ee; }
+      .green { stroke: #2fbf5a; }
+      .greenring { stroke: #2fbf5a; stroke-opacity: 0.55; }
+      .spark { stroke: #ff7a4d; }
+      .dot { fill: #f2f2ee; opacity: 0.07; }
+    }
+    @keyframes flow { to { stroke-dashoffset: -240; } }
+    @media (prefers-reduced-motion: reduce) { .flow-fast, .flow-slow { animation: none; } }
+  </style>
+
+  <pattern id="cdots" width="24" height="24" patternUnits="userSpaceOnUse"><circle class="dot" cx="2" cy="2" r="1.6" /></pattern>
+  <rect class="bg" x="0" y="0" width="1200" height="520" />
+  <rect x="0" y="0" width="1200" height="520" fill="url(#cdots)" />
+
+  <text class="kicker" x="120" y="86">// the cheapest path to green</text>
+
+  <!-- battery / source -->
+  <g class="ink">
+    <rect x="96" y="238" width="8" height="48" rx="2" />
+    <rect x="116" y="252" width="6" height="20" rx="2" />
+  </g>
+  <text class="label" x="70" y="330">in</text>
+
+  <!-- base wiring -->
+  <!-- source to split -->
+  <path class="wire" d="M122 262 H300" />
+  <!-- top branch: up, across (with resistor gap), down -->
+  <path class="wire" d="M300 262 V150 H470" />
+  <path class="wire" d="M690 150 H900 V262" />
+  <!-- resistor (zigzag) on top branch -->
+  <path class="wire" d="M470 150 l14 -16 l28 32 l28 -32 l28 32 l28 -32 l28 32 l14 -16 H690" />
+  <!-- bottom branch: the short -->
+  <path class="wire" d="M300 262 V378 H900 V262" />
+  <!-- merge to target -->
+  <path class="wire" d="M900 262 H980" />
+
+  <!-- current flow overlays -->
+  <!-- top branch, little current -->
+  <path class="flow flow-slow" d="M300 262 V150 H470 M690 150 H900" />
+  <!-- bottom branch, most of the current -->
+  <path class="flow flow-fast" d="M300 262 V378 H900 V262 H980" />
+
+  <!-- nodes -->
+  <circle class="node" cx="300" cy="262" r="6" />
+  <circle class="node" cx="900" cy="262" r="6" />
+
+  <!-- labels -->
+  <text class="label" x="486" y="126">actually fix it</text>
+  <text class="label" x="520" y="418">delete the test</text>
+
+  <!-- spark on the short -->
+  <g class="spark">
+    <path d="M596 378 l-16 -22 M596 378 l20 -16 M596 378 l-6 26 M596 378 l24 10" />
+  </g>
+
+  <!-- target: green check -->
+  <circle class="greenring" cx="1030" cy="262" r="52" />
+  <path class="green" d="M1006 262 l16 18 l34 -40" />
+</svg>


### PR DESCRIPTION
### 🔗 Linked issue

N/A. No tracking issue.

### 🧭 Context

A personal essay for the blog. It comes out of a frustration I kept hitting with AI agents: the agent says "done" when the tests never ran, the data was invented, or an `any` got taped over the warning light. I wanted to explain why that happens without hand-waving, so I reached back to a trick from electronics class to make it concrete.

This is a draft, sharing for review before it goes live.

### 📚 Description

The essay walks an arc from the frustration to a physical analogy and back to something honest:

- The frustration: the corner-cut that looks like completion (the kid who shoves everything under the bed).
- The bypass capacitor: a real memory from electronics, where an emitter resistor steadies an amplifier but eats gain; drop a capacitor across it and the signal takes the easy path around the resistor. Current takes the cheapest path you leave open, every time.
- Don't blame the electron: an agent's `any`, faked data, or deleted test is a bypass capacitor; the behaviour has a name (specification gaming / reward hacking); you wired the circuit.
- The amplifier: that resistor is negative feedback (gain traded for control); a bypass cap is an honest trade, but deleting the test cuts the feedback loop entirely and the amp oscillates and clips, which is reward tampering.
- The room, still messy: no clean fix; recognising the move in myself; choosing the resistor anyway.

Ships with three theme-aware SVGs (light/dark, reduced-motion safe, with animated current flow): `cover.svg`, `bypass-capacitor.svg`, `amplifier.svg`.

No automated tests, since it's prose plus static assets.
