### PR TITLE
feat(feed): full content for own posts + Medium backlinks in RSS

### DIFF
--- a/server/routes/feed.xml.get.ts
+++ b/server/routes/feed.xml.get.ts
@@ -1,11 +1,30 @@
 import { queryCollection } from '@nuxt/content/server'
 import { Feed } from 'feed'
+import { mediumPosts } from '~/data/medium-posts'
 
 export default defineEventHandler(async (event) => {
   const site = String(useRuntimeConfig(event).public.siteUrl).replace(/\/$/, '')
 
-  const posts = (await queryCollection(event, 'blog').order('date', 'DESC').all())
+  const onSite = (await queryCollection(event, 'blog').order('date', 'DESC').all())
     .filter(p => !p.draft)
+    .map(p => ({
+      title: p.title,
+      link: `${site}${p.path}`,
+      description: p.description ?? '',
+      content: minimarkToHtml(p.body).replace(/(src|href)="\//g, `$1="${site}/`),
+      date: p.date,
+    }))
+
+  const external = mediumPosts.map(m => ({
+    title: m.title,
+    link: m.url,
+    description: m.description ?? '',
+    content: '',
+    date: m.date,
+  }))
+
+  const posts = [...onSite, ...external]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
   const feed = new Feed({
     title: 'Adebesin Tolulope (Lope) — Blog',
@@ -22,9 +41,10 @@ export default defineEventHandler(async (event) => {
   for (const p of posts) {
     feed.addItem({
       title: p.title,
-      id: `${site}${p.path}`,
-      link: `${site}${p.path}`,
-      description: p.description ?? '',
+      id: p.link,
+      link: p.link,
+      description: p.description,
+      content: p.content || undefined,
       date: new Date(p.date),
     })
   }

--- a/server/utils/minimark-to-html.ts
+++ b/server/utils/minimark-to-html.ts
@@ -1,0 +1,37 @@
+type MinimarkNode = string | [string, Record<string, unknown>, ...MinimarkNode[]]
+
+const VOID = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+  'input', 'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+function escapeText(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function escapeAttr(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+}
+
+function nodeToHtml(node: MinimarkNode): string {
+  if (typeof node === 'string')
+    return escapeText(node)
+
+  const [tag, props, ...children] = node
+  const attrs = Object.entries(props ?? {})
+    .filter(([, v]) => v != null && v !== false)
+    .map(([k, v]) => (v === true ? ` ${k}` : ` ${k}="${escapeAttr(Array.isArray(v) ? v.join(' ') : String(v))}"`))
+    .join('')
+
+  if (VOID.has(tag))
+    return `<${tag}${attrs}>`
+
+  return `<${tag}${attrs}>${children.map(nodeToHtml).join('')}</${tag}>`
+}
+
+// ponytail: minimal serializer for the author's own trusted content; not hardened against `]]>` inside CDATA (won't occur in these essays)
+export function minimarkToHtml(body: { value?: MinimarkNode[] } | null | undefined): string {
+  if (!body?.value)
+    return ''
+  return body.value.map(nodeToHtml).join('')
+}


### PR DESCRIPTION
### 🔗 Linked issue

N/A. No tracking issue.

### 🧭 Context

In a feed reader, each of my own posts only carried the one-line `description`, so a post like "Context is everything" rendered as a thin/empty stub. My Medium posts were also missing from the feed entirely.

### 📚 Description

Two changes to `feed.xml`:

- My own posts now include full `content:encoded`. I serialize the post body (minimark AST) to HTML and rewrite `src`/`href` to absolute URLs so images and internal links resolve in a reader.
- Medium posts are now in the feed as link-only backlinks (`link` → medium.com), merged with on-site posts and sorted by date, mirroring what `blog/index.vue` already does.

I added `server/utils/minimark-to-html.ts`, a small self-contained serializer for @nuxt/content's minimark body format (text/attr escaping, void elements), so the nitro route doesn't pull in transitive-only deps. `server/routes/feed.xml.get.ts` merges the on-site and Medium items and attaches `content:encoded` to on-site posts only.

I verified it against real content via the dev server (13 items, own posts carry `content:encoded`, Medium posts link out), confirmed the output is well-formed with `xmllint --noout`, and checked that image/link URLs come out absolute.
