### PR TITLE
feat(feed): styled RSS page, clean code blocks, canonical backlinks

### DIFF
--- a/public/feed.xsl
+++ b/public/feed.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <xsl:output method="html" encoding="utf-8" indent="yes"/>
+  <xsl:template match="/">
+    <html lang="en">
+      <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title><xsl:value-of select="rss/channel/title"/> — RSS feed</title>
+        <style>
+          :root { color-scheme: light dark; }
+          body { max-width: 40rem; margin: 3rem auto; padding: 0 1.25rem;
+            font: 1rem/1.65 system-ui, sans-serif; }
+          .note { padding: .85rem 1rem; border: 1px solid color-mix(in oklab, currentColor 20%, transparent);
+            border-radius: .5rem; font-size: .9rem; opacity: .85; margin-bottom: 2.5rem; }
+          h1 { font-size: 1.6rem; margin: 0 0 .25rem; }
+          .desc { opacity: .75; margin: 0 0 2rem; }
+          ul { list-style: none; padding: 0; }
+          li { padding: 1rem 0; border-top: 1px solid color-mix(in oklab, currentColor 15%, transparent); }
+          a { color: inherit; }
+          time { font-size: .8rem; opacity: .6; display: block; margin-bottom: .2rem; }
+          .item-desc { opacity: .75; font-size: .92rem; margin: .3rem 0 0; }
+        </style>
+      </head>
+      <body>
+        <div class="note">
+          📡 This is an RSS feed. Copy the URL into a feed reader to subscribe.
+        </div>
+        <h1><xsl:value-of select="rss/channel/title"/></h1>
+        <p class="desc"><xsl:value-of select="rss/channel/description"/></p>
+        <ul>
+          <xsl:for-each select="rss/channel/item">
+            <li>
+              <time><xsl:value-of select="pubDate"/></time>
+              <a href="{link}"><xsl:value-of select="title"/></a>
+              <p class="item-desc"><xsl:value-of select="description"/></p>
+            </li>
+          </xsl:for-each>
+        </ul>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/server/routes/feed.xml.get.ts
+++ b/server/routes/feed.xml.get.ts
@@ -9,9 +9,9 @@ export default defineEventHandler(async (event) => {
     .filter(p => !p.draft)
     .map(p => ({
       title: p.title,
-      link: `${site}${p.path}`,
+      link: p.canonical ?? `${site}${p.path}`,
       description: p.description ?? '',
-      content: minimarkToHtml(p.body).replace(/(src|href)="\//g, `$1="${site}/`),
+      content: p.canonical ? '' : minimarkToHtml(p.body).replace(/(src|href)="\//g, `$1="${site}/`),
       date: p.date,
     }))
 
@@ -50,5 +50,8 @@ export default defineEventHandler(async (event) => {
   }
 
   setHeader(event, 'content-type', 'application/rss+xml; charset=utf-8')
-  return feed.rss2()
+  return feed.rss2().replace(
+    /^<\?xml[^>]*\?>/,
+    `$&\n<?xml-stylesheet type="text/xsl" href="/feed.xsl"?>`,
+  )
 })

--- a/server/utils/minimark-to-html.ts
+++ b/server/utils/minimark-to-html.ts
@@ -18,6 +18,13 @@ function nodeToHtml(node: MinimarkNode): string {
     return escapeText(node)
 
   const [tag, props, ...children] = node
+
+  // shiki dumps highlight spans + a <style> block into the body; feeds want neither.
+  if (tag === 'style')
+    return ''
+  if (tag === 'pre' && props?.code != null)
+    return `<pre><code>${escapeText(String(props.code))}</code></pre>`
+
   const attrs = Object.entries(props ?? {})
     .filter(([, v]) => v != null && v !== false)
     .map(([k, v]) => (v === true ? ` ${k}` : ` ${k}="${escapeAttr(Array.isArray(v) ? v.join(' ') : String(v))}"`))


### PR DESCRIPTION
### 🔗 Linked issue

N/A. No tracking issue.

### 🧭 Context

A follow-up to the full-content feed work. Opening `/feed.xml` in a browser showed raw XML, the serialized `content:encoded` was leaking shiki highlight markup, and posts re-published to Medium (with a `canonical`) were duplicating their body.

### 📚 Description

- Styled feed page: I added `public/feed.xsl` plus a stylesheet processing instruction, so opening `/feed.xml` in a browser renders a titled HTML page (with a proper tab title) instead of raw XML. Feed readers still get plain RSS.
- Clean code blocks: `content:encoded` no longer leaks shiki highlight spans or trailing `<style>` blocks. `pre` nodes now emit a plain `<pre><code>` from the stored raw source, and `style` nodes are dropped.
- Canonical backlinks: posts with a `canonical` (Medium re-posts) now link to the canonical URL with an empty body, matching the pure-Medium backlink behavior.
