### PR TITLE
feat(talks): topic cards with logos and confident intro

### DIFF
--- a/app/components/Chip.vue
+++ b/app/components/Chip.vue
@@ -25,9 +25,9 @@ const linkAttrs = computed(() =>
 
 <template>
   <component :is="tag" v-bind="linkAttrs" class="chip">
-    <ark.span class="grid place-items-center w-[18px] h-[18px] shrink-0" aria-hidden="true">
+    <ark.span v-if="logo || icon" class="grid place-items-center w-[18px] h-[18px] shrink-0" aria-hidden="true">
       <BrandLogo v-if="logo" :src="logo" :light="logoLight" :alt="label" class="w-full h-full" />
-      <ark.span v-else-if="icon" :class="icon" class="w-full! h-full!" :style="color ? { color } : undefined" />
+      <ark.span v-else :class="icon" class="w-full! h-full!" :style="color ? { color } : undefined" />
     </ark.span>
     <ark.span>{{ label }}</ark.span>
   </component>

--- a/app/components/TalkCard.vue
+++ b/app/components/TalkCard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ark } from '@ark-ui/vue/factory'
+import type { Talk } from '~~/shared/data/talks'
+
+defineProps<{ talk: Talk }>()
+</script>
+
+<template>
+  <ark.a
+    :href="talk.href"
+    target="_blank"
+    rel="noopener"
+    class="group flex flex-col gap-3 p-5 rounded-xl border border-ink/10 transition-colors hover:border-ink/25 hover:bg-ink/2"
+  >
+    <ark.div class="flex items-center gap-3">
+      <ark.div class="w-9 h-9 shrink-0 rounded-lg overflow-hidden">
+        <ark.img
+          :src="talk.logo"
+          :alt="talk.name"
+          loading="lazy"
+          class="w-full h-full object-cover op-90 group-hover:op-100 transition-opacity"
+        />
+      </ark.div>
+      <ark.h3 class="text-sm font-600 text-ink">
+        {{ talk.name }}
+      </ark.h3>
+    </ark.div>
+
+    <ark.p class="text-xs text-ink-muted leading-relaxed">
+      {{ talk.angle }}
+    </ark.p>
+
+    <ark.div class="flex flex-wrap gap-1.5 mt-auto">
+      <Chip v-for="topic in talk.topics" :key="topic" :label="topic" />
+    </ark.div>
+  </ark.a>
+</template>

--- a/app/pages/talks.vue
+++ b/app/pages/talks.vue
@@ -1,31 +1,42 @@
 <script setup lang="ts">
 import { ark } from '@ark-ui/vue/factory'
+import { talks } from '~~/shared/data/talks'
 
 usePageSeo({
   title: 'Talks — Adebesin Tolulope',
-  description: 'Where Lope wants to be on stage — speaking plans, starting with meetups.',
+  description: 'What Lope would love to talk about: Panda, Chakra, Zag, Ark UI, and open source.',
 })
 </script>
 
 <template>
   <ark.article class="slide-enter-content">
-    <ark.h1 class="text-4xl font-700 tracking-tight mb-3">
-      Talks
-    </ark.h1>
-    <ark.p class="text-ink-muted mb-10">
-      Nothing on stage yet — but that's the plan.
-    </ark.p>
+    <ark.header class="text-center mb-12">
+      <ark.h1 class="text-4xl font-700 tracking-tight mb-3">
+        Talks
+      </ark.h1>
+      <ark.p class="text-ink-muted">
+        Talks I'd love to share, on the tools I build and maintain every day.
+      </ark.p>
+    </ark.header>
 
-    <ark.div class="rounded-lg border border-ink/10 p-6 bg-ink/2">
+    <ark.section>
+      <ark.h2 class="text-xs uppercase tracking-wider text-ink-muted font-500 mb-4">
+        What I'd love to talk about
+      </ark.h2>
+      <ark.div class="grid gap-4 sm:grid-cols-2">
+        <TalkCard v-for="talk in talks" :key="talk.name" :talk="talk" />
+      </ark.div>
+    </ark.section>
+
+    <ark.div class="mt-12 rounded-lg border border-ink/10 p-6 bg-ink/2">
       <ark.h2 class="text-lg font-600 mb-2">
-        The wish
+        The dream stage
       </ark.h2>
       <ark.p class="text-sm text-ink-muted leading-relaxed">
-        I haven't given a conference talk yet — but it's a goal. Speaking at
-        <ark.span class="text-ink font-500">React Conf</ark.span> is right at the top of my list.
+        <ark.span class="text-ink font-500">React Conf</ark.span> is the one I'm aiming for.
       </ark.p>
       <ark.p class="text-sm text-ink-muted leading-relaxed mt-3">
-        If you're organising a meetup or conference and want me there, reach me on
+        Organising a meetup or conference? I'd love to give a talk. Reach me on
         <ark.a href="https://www.linkedin.com/in/adebesin-tolulope/" class="underline">LinkedIn</ark.a>.
       </ark.p>
     </ark.div>

--- a/app/pages/talks.vue
+++ b/app/pages/talks.vue
@@ -33,7 +33,9 @@ usePageSeo({
         The dream stage
       </ark.h2>
       <ark.p class="text-sm text-ink-muted leading-relaxed">
-        <ark.span class="text-ink font-500">React Conf</ark.span> is the one I'm aiming for.
+        <ark.span class="text-ink font-500">React Conf</ark.span>,
+        <ark.span class="text-ink font-500">VueConf</ark.span> (yes, I write Vue too), the big
+        open-source gatherings. The dream is being on stage with the community I build alongside.
       </ark.p>
       <ark.p class="text-sm text-ink-muted leading-relaxed mt-3">
         Organising a meetup or conference? I'd love to give a talk. Reach me on

--- a/shared/data/talks.ts
+++ b/shared/data/talks.ts
@@ -1,0 +1,46 @@
+export interface Talk {
+  name: string
+  angle: string
+  href: string
+  topics: string[]
+  // Logo path under /public, or a remote URL (e.g. a GitHub org avatar).
+  logo: string
+}
+
+export const talks: Talk[] = [
+  {
+    name: 'Panda CSS',
+    angle: 'Build-time styling done right: the mental model, the v2 engine, and migrating.',
+    href: 'https://panda-css.com',
+    logo: '/brands/panda.png',
+    topics: ['the v2 engine', 'zero-runtime', 'migrating from v1'],
+  },
+  {
+    name: 'Chakra UI',
+    angle: 'Composition, theming, and the DX decisions behind it, from a maintainer.',
+    href: 'https://chakra-ui.com',
+    logo: 'https://github.com/chakra-ui.png',
+    topics: ['composition', 'theming', 'maintainer notes'],
+  },
+  {
+    name: 'Zag.js',
+    angle: 'UI as state machines. Framework-agnostic components that stay accessible.',
+    href: 'https://zagjs.com',
+    logo: '/brands/zag.png',
+    topics: ['statecharts', 'accessibility', 'framework-agnostic'],
+  },
+  {
+    name: 'Ark UI',
+    angle: 'Headless, accessible components built on top of Zag state machines.',
+    href: 'https://ark-ui.com',
+    logo: '/brands/ark.png',
+    topics: ['headless', 'accessibility', 'design-system foundation'],
+  },
+  {
+    name: 'Open source',
+    angle: 'Contributing, maintaining, and keeping the ecosystem healthy.',
+    href: 'https://github.com/Adebesin-Cell',
+    logo: 'https://github.com/Adebesin-Cell.png',
+    topics: ['maintaining', 'e18e / perf', 'first contributions'],
+  },
+]


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The Talks page only had a placeholder wish. I know exactly what I'd love to speak on, so this turns it into a real showcase of the tools I build and maintain.

### 📚 Description

Rebuilt the Talks page around concrete topics, each as a card:

- **Panda CSS**, **Chakra UI**, **Zag.js**, **Ark UI**, and **open source**
- Every card has a brand logo, a one-line angle, and sub-topic chips, and links out to the project
- Logos come from the local `public/brands` marks and GitHub avatars, the same image approach the Releases page uses
- The dream-stage section covers React Conf, VueConf, and the wider open-source community, with a LinkedIn CTA

Also a small fix in `Chip`: it now only renders the icon slot when an `icon` or `logo` is set, so text-only chips (the topic tags) no longer carry an empty 18px gap on the left. Icon/logo chips on the homepage are unaffected.

Data lives in `shared/data/talks.ts`, matching the `projects.ts` / `play.ts` pattern; rendering is a single `TalkCard.vue`.