### PR TITLE
fix(blog): correct quietest-bug publish date to Jul 16

### DIFF
--- a/content/blog/quietest-bug.md
+++ b/content/blog/quietest-bug.md
@@ -1,7 +1,7 @@
 ---
 title: The quietest kind of bug
 description: Optional chaining hides the failure you most need to see. A user found a bug in BethelFlow before I did because of it. My honest take, and the rule I keep.
-date: 2026-09-07
+date: 2026-07-16
 readingTime: 6min
 ---
 


### PR DESCRIPTION
### 🧭 Context

The quietest kind of bug was live on prod showing a publish date of **Sep 7, 2026** — a future date. The date frontmatter had been fat-fingered.

### 📚 Description

Corrects the `date` frontmatter in `content/blog/quietest-bug.md` from `2026-09-07` to `2026-07-16`, the date the post was actually committed and published. No other changes.
