### PR TITLE
feat(blog): make the highlight card on-brand

### DIFF
--- a/app/components/HighlightShare.vue
+++ b/app/components/HighlightShare.vue
@@ -138,21 +138,21 @@ if (import.meta.client) {
           <ark.div class="flex flex-wrap items-center justify-center gap-2.5">
             <ark.button
               type="button"
-              aria-label="Download a square card for Instagram"
+              aria-label="Save a square card for Instagram"
               class="btn"
               :class="format === 'ig' ? 'btn-solid' : 'btn-ghost'"
               @click="download('ig')"
             >
-              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Instagram
+              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Save for Instagram
             </ark.button>
             <ark.button
               type="button"
-              aria-label="Download a wide card for X"
+              aria-label="Save a wide card for X"
               class="btn"
               :class="format === 'x' ? 'btn-solid' : 'btn-ghost'"
               @click="download('x')"
             >
-              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> X
+              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Save for X
             </ark.button>
             <ark.button
               type="button"

--- a/app/components/HighlightShare.vue
+++ b/app/components/HighlightShare.vue
@@ -2,9 +2,11 @@
 import type { CardFormat } from '~/composables/useHighlightCard'
 import { ark } from '@ark-ui/vue/factory'
 
-const props = defineProps<{ title?: string, url?: string }>()
+const props = defineProps<{ title?: string, url?: string, date?: string }>()
 
 const { draw } = useHighlightCard()
+
+const year = computed(() => (props.date ? String(new Date(props.date).getFullYear()) : undefined))
 
 const open = ref(false)
 const quote = ref('')
@@ -44,7 +46,7 @@ async function download(fmt: CardFormat) {
   format.value = fmt
   if (!canvasRef.value)
     return
-  await draw(canvasRef.value, fmt, { quote: quote.value, title: props.title, url: props.url })
+  await draw(canvasRef.value, fmt, { quote: quote.value, title: props.title, url: props.url, year: year.value })
   canvasRef.value.toBlob((blob) => {
     if (!blob)
       return
@@ -59,7 +61,7 @@ async function download(fmt: CardFormat) {
 async function copyCard() {
   if (!canvasRef.value)
     return
-  await draw(canvasRef.value, format.value, { quote: quote.value, title: props.title, url: props.url })
+  await draw(canvasRef.value, format.value, { quote: quote.value, title: props.title, url: props.url, year: year.value })
   canvasRef.value.toBlob(async (blob) => {
     try {
       if (!blob)
@@ -125,18 +127,19 @@ if (import.meta.client) {
           ref="dialogRef"
           role="dialog"
           aria-modal="true"
-          aria-label="Share highlight as a card"
+          aria-label="Share this highlight"
           tabindex="-1"
           class="fixed inset-0 z-[200] flex flex-col items-center justify-center gap-5 bg-black/55 p-6 backdrop-blur-md outline-none"
           @click.self="close"
           @keydown="trapTab"
         >
-          <ShareCard :quote="quote" :title="title" :url="url" :format="format" />
+          <ShareCard :quote="quote" :title="title" :url="url" :year="year" :format="format" />
 
           <ark.div class="flex items-center gap-1 rounded-xl border border-ink/12 bg-bg-soft/85 p-1.5 text-sm shadow-xl">
             <ark.span class="mx-2 h-3 w-3 rounded-full border-2 border-ink/40" aria-hidden="true" />
             <ark.button
               type="button"
+              aria-label="Download a square card for Instagram"
               class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg hover:bg-ink/8 transition-colors"
               :class="format === 'ig' ? 'text-ink' : 'text-ink-muted'"
               @click="download('ig')"
@@ -145,6 +148,7 @@ if (import.meta.client) {
             </ark.button>
             <ark.button
               type="button"
+              aria-label="Download a wide card for X"
               class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg hover:bg-ink/8 transition-colors"
               :class="format === 'x' ? 'text-ink' : 'text-ink-muted'"
               @click="download('x')"
@@ -153,6 +157,7 @@ if (import.meta.client) {
             </ark.button>
             <ark.button
               type="button"
+              aria-label="Copy the card to your clipboard"
               class="inline-flex items-center h-9 px-3 rounded-lg text-ink-muted hover:bg-ink/8 hover:text-ink transition-colors"
               @click="copyCard"
             >

--- a/app/components/HighlightShare.vue
+++ b/app/components/HighlightShare.vue
@@ -135,42 +135,45 @@ if (import.meta.client) {
         >
           <ShareCard :quote="quote" :title="title" :url="url" :year="year" :format="format" />
 
-          <ark.div class="flex items-center gap-1 rounded-xl border border-ink/12 bg-bg-soft/85 p-1.5 text-sm shadow-xl">
-            <ark.span class="mx-2 h-3 w-3 rounded-full border-2 border-ink/40" aria-hidden="true" />
+          <ark.div class="flex flex-wrap items-center justify-center gap-2.5">
             <ark.button
               type="button"
               aria-label="Download a square card for Instagram"
-              class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg hover:bg-ink/8 transition-colors"
-              :class="format === 'ig' ? 'text-ink' : 'text-ink-muted'"
+              class="btn"
+              :class="format === 'ig' ? 'btn-solid' : 'btn-ghost'"
               @click="download('ig')"
             >
-              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Download IG
+              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Instagram
             </ark.button>
             <ark.button
               type="button"
               aria-label="Download a wide card for X"
-              class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg hover:bg-ink/8 transition-colors"
-              :class="format === 'x' ? 'text-ink' : 'text-ink-muted'"
+              class="btn"
+              :class="format === 'x' ? 'btn-solid' : 'btn-ghost'"
               @click="download('x')"
             >
-              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> Download X
+              <ark.span class="i-lucide-arrow-down" aria-hidden="true" /> X
             </ark.button>
             <ark.button
               type="button"
               aria-label="Copy the card to your clipboard"
-              class="inline-flex items-center h-9 px-3 rounded-lg text-ink-muted hover:bg-ink/8 hover:text-ink transition-colors"
+              class="btn btn-ghost"
               @click="copyCard"
             >
+              <ark.span :class="copied ? 'i-lucide-check' : 'i-lucide-copy'" aria-hidden="true" />
               {{ copied ? 'Copied' : 'Copy' }}
             </ark.button>
-            <ark.button
-              type="button"
-              class="inline-flex items-center gap-2 h-9 px-3 rounded-lg text-ink-faint hover:bg-ink/8 hover:text-ink transition-colors"
-              @click="close"
-            >
-              Close <ark.kbd class="text-xs font-mono italic">esc</ark.kbd>
-            </ark.button>
           </ark.div>
+
+          <ark.button
+            type="button"
+            aria-label="Close"
+            title="Close (Esc)"
+            class="absolute top-5 end-5 inline-flex items-center justify-center w-9 h-9 rounded-lg text-ink-muted hover:text-ink hover:bg-ink/10 transition-colors"
+            @click="close"
+          >
+            <ark.span class="i-lucide-x text-lg" aria-hidden="true" />
+          </ark.button>
 
           <canvas ref="canvasRef" class="hidden" aria-hidden="true" />
         </ark.div>

--- a/app/components/ShareCard.vue
+++ b/app/components/ShareCard.vue
@@ -42,7 +42,7 @@ const quoteStyle = computed(() => {
       preserveAspectRatio="xMidYMid slice"
       aria-hidden="true"
     >
-      <ark.path :d="branches.d" fill="none" stroke="rgba(210,210,215,0.16)" stroke-width="1" stroke-linecap="round" />
+      <ark.path :d="branches.d" fill="none" stroke="rgba(210,210,215,0.13)" stroke-width="1" stroke-linecap="round" />
     </ark.svg>
 
     <ark.header class="head">

--- a/app/components/ShareCard.vue
+++ b/app/components/ShareCard.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   quote: string
   title?: string
   url?: string
+  year?: string
   format: CardFormat
 }>()
 
@@ -32,6 +33,9 @@ const quoteStyle = computed(() => {
     class="share-card"
     :class="format === 'ig' ? 'w-[clamp(320px,72vw,560px)]' : 'w-[clamp(360px,86vw,860px)]'"
   >
+    <ark.div class="dots" aria-hidden="true" />
+    <ark.span v-if="year" class="watermark" aria-hidden="true">{{ year }}</ark.span>
+
     <ark.svg
       class="branches"
       :viewBox="`0 0 ${branches.w} ${branches.h}`"
@@ -41,18 +45,18 @@ const quoteStyle = computed(() => {
       <ark.path :d="branches.d" fill="none" stroke="rgba(210,210,215,0.16)" stroke-width="1" stroke-linecap="round" />
     </ark.svg>
 
-    <ark.span class="corner c-tl" aria-hidden="true" />
-    <ark.span class="corner c-tr" aria-hidden="true" />
-    <ark.span class="corner c-bl" aria-hidden="true" />
-    <ark.span class="corner c-br" aria-hidden="true" />
-
     <ark.header class="head">
       <ark.div class="who">
         <ark.img src="/lope-avatar.jpeg" alt="" class="avatar" />
         <ark.span class="name">Adebesin Tolulope</ark.span>
-        <ark.span class="tag">/ Blog</ark.span>
+        <ark.span class="alias">(Lope)</ark.span>
       </ark.div>
-      <ark.span class="label">PULLED FROM THE POST</ark.span>
+      <ClientOnly>
+        <TegakiRenderer :font="caveat" text="at" :time="{ mode: 'uncontrolled', loop: true, speed: 0.6 }" class="stamp" />
+        <template #fallback>
+          <ark.span class="stamp">at</ark.span>
+        </template>
+      </ClientOnly>
     </ark.header>
 
     <ark.div class="body">
@@ -63,21 +67,19 @@ const quoteStyle = computed(() => {
     </ark.div>
 
     <ark.footer class="foot">
-      <ClientOnly>
-        <TegakiRenderer
-          :font="caveat"
-          text="— Lope"
-          :time="{ mode: 'uncontrolled', loop: false, speed: 0.9 }"
-          class="sign"
-        />
-        <template #fallback>
-          <ark.span class="sign">— Lope</ark.span>
-        </template>
-      </ClientOnly>
-      <ark.div v-if="title || url" class="source">
-        <ark.span v-if="title" class="from">from “{{ title }}”</ark.span>
+      <ark.div class="sign-col">
+        <ClientOnly>
+          <TegakiRenderer :font="caveat" text="— Lope" :time="{ mode: 'uncontrolled', loop: false, speed: 0.9 }" class="sign" />
+          <template #fallback>
+            <ark.span class="sign">— Lope</ark.span>
+          </template>
+        </ClientOnly>
         <ark.span v-if="url" class="link">{{ cleanUrl }}</ark.span>
       </ark.div>
+      <ark.span v-if="title" class="source">
+        <ark.span class="i-lucide-newspaper source-icon" aria-hidden="true" />
+        <ark.span class="source-title">{{ title }}</ark.span>
+      </ark.span>
     </ark.footer>
   </ark.figure>
 </template>
@@ -98,27 +100,40 @@ const quoteStyle = computed(() => {
   color: #f4f4f5;
 }
 
+.dots {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(244, 244, 245, 0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+.watermark {
+  position: absolute;
+  right: -1.5cqw;
+  bottom: -6cqw;
+  z-index: 0;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 36cqw;
+  letter-spacing: -0.04em;
+  line-height: 0.8;
+  color: rgba(244, 244, 245, 0.05);
+  pointer-events: none;
+  user-select: none;
+}
 .branches {
   position: absolute;
   inset: 0;
+  z-index: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
 }
 
-.corner {
-  position: absolute;
-  width: 4cqw;
-  height: 4cqw;
-  border: 0 solid rgba(244, 244, 245, 0.28);
-}
-.c-tl { top: 3cqw; left: 3cqw; border-top-width: 1.5px; border-left-width: 1.5px; }
-.c-tr { top: 3cqw; right: 3cqw; border-top-width: 1.5px; border-right-width: 1.5px; }
-.c-bl { bottom: 3cqw; left: 3cqw; border-bottom-width: 1.5px; border-left-width: 1.5px; }
-.c-br { bottom: 3cqw; right: 3cqw; border-bottom-width: 1.5px; border-right-width: 1.5px; }
-
 .head {
   position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -143,22 +158,23 @@ const quoteStyle = computed(() => {
   font-size: 1.7cqw;
   white-space: nowrap;
 }
-.tag {
-  font-family: 'Newsreader', serif;
-  font-style: italic;
+.alias {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
   font-size: 1.7cqw;
   color: rgba(161, 161, 170, 0.9);
 }
-.label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 1cqw;
-  letter-spacing: 0.22em;
-  color: #71717a;
-  white-space: nowrap;
+.stamp {
+  font-family: 'Caveat', cursive;
+  font-weight: 700;
+  font-size: 3.4cqw;
+  line-height: 1;
+  color: rgba(161, 161, 170, 0.9);
 }
 
 .body {
   position: relative;
+  z-index: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -182,33 +198,52 @@ const quoteStyle = computed(() => {
 
 .foot {
   position: relative;
+  z-index: 1;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
   gap: 2cqw;
   margin-top: 5cqw;
 }
+.sign-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8cqw;
+}
 .sign {
   font-family: 'Caveat', cursive;
   font-weight: 600;
   font-size: 3.2cqw;
+  line-height: 1;
   color: #f4f4f5;
 }
-.source {
-  text-align: right;
-  line-height: 1.5;
-}
-.from {
-  display: block;
-  font-family: 'Newsreader', serif;
-  font-style: italic;
-  font-size: 1.35cqw;
-  color: rgba(161, 161, 170, 0.9);
-}
 .link {
-  display: block;
   font-family: 'JetBrains Mono', monospace;
   font-size: 1cqw;
   color: #71717a;
+}
+.source {
+  display: inline-flex;
+  align-items: center;
+  gap: 1cqw;
+  max-width: 50cqw;
+  padding: 1cqw 1.6cqw;
+  border-radius: 8px;
+  background: rgba(244, 244, 245, 0.05);
+  border: 1px solid rgba(244, 244, 245, 0.1);
+}
+.source-icon {
+  flex-shrink: 0;
+  width: 1.6cqw;
+  height: 1.6cqw;
+  color: rgba(161, 161, 170, 0.9);
+}
+.source-title {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 1.5cqw;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/app/composables/useHighlightCard.ts
+++ b/app/composables/useHighlightCard.ts
@@ -94,7 +94,7 @@ export function plumSegments(w: number, h: number, seed: number): PlumSegment[] 
   const len = w / 260
   const segs: PlumSegment[] = []
   const step = (x: number, y: number, rad: number) => {
-    if (segs.length > 3200)
+    if (segs.length > 6500)
       return
     const length = rand() * len
     const nx = x + Math.cos(rad) * length
@@ -108,14 +108,17 @@ export function plumSegments(w: number, h: number, seed: number): PlumSegment[] 
     if (rand() < rate)
       step(nx, ny, rad - rand() * r15)
   }
-  step(w + 5, rand() * h * 0.5 + h * 0.15, r180)
-  step(rand() * w * 0.4 + w * 0.55, -5, r90)
+  const mid = () => 0.15 + rand() * 0.7
+  step(mid() * w, -5, r90)
+  step(mid() * w, h + 5, -r90)
+  step(-5, mid() * h, 0)
+  step(w + 5, mid() * h, r180)
   return segs
 }
 
 function drawPlum(ctx: CanvasRenderingContext2D, w: number, h: number, seed: number) {
   ctx.save()
-  ctx.strokeStyle = 'rgba(210,210,215,0.16)'
+  ctx.strokeStyle = 'rgba(210,210,215,0.13)'
   ctx.lineWidth = 1
   ctx.lineCap = 'round'
   for (const [x1, y1, x2, y2] of plumSegments(w, h, seed)) {

--- a/app/composables/useHighlightCard.ts
+++ b/app/composables/useHighlightCard.ts
@@ -2,6 +2,7 @@ export interface CardData {
   quote: string
   title?: string
   url?: string
+  year?: string
 }
 
 export type CardFormat = 'x' | 'ig'
@@ -144,23 +145,29 @@ export function useHighlightCard() {
 
     const P = Math.round(w * 0.07)
     const contentW = w - P * 2
-    const inset = Math.round(P * 0.55)
-    drawPlum(ctx, w, h, PLUM_SEED)
 
-    const L = 26
-    ctx.strokeStyle = 'rgba(244,244,245,0.28)'
-    ctx.lineWidth = 1.5
-    const corner = (cx: number, cy: number, dx: number, dy: number) => {
-      ctx.beginPath()
-      ctx.moveTo(cx, cy + dy * L)
-      ctx.lineTo(cx, cy)
-      ctx.lineTo(cx + dx * L, cy)
-      ctx.stroke()
+    ctx.fillStyle = 'rgba(244,244,245,0.05)'
+    const dot = 26
+    for (let gx = P * 0.5; gx < w; gx += dot) {
+      for (let gy = P * 0.5; gy < h; gy += dot) {
+        ctx.beginPath()
+        ctx.arc(gx, gy, 1, 0, Math.PI * 2)
+        ctx.fill()
+      }
     }
-    corner(inset, inset, 1, 1)
-    corner(w - inset, inset, -1, 1)
-    corner(inset, h - inset, 1, -1)
-    corner(w - inset, h - inset, -1, -1)
+
+    if (data.year) {
+      ctx.save()
+      ctx.textAlign = 'right'
+      ctx.fillStyle = 'rgba(244,244,245,0.05)'
+      ctx.letterSpacing = `${-w * 0.006}px`
+      ctx.font = `700 ${Math.round(Math.min(w * 0.28, h * 0.42))}px Inter, sans-serif`
+      ctx.fillText(data.year, w - P * 0.4, h + w * 0.02)
+      ctx.letterSpacing = '0px'
+      ctx.restore()
+    }
+
+    drawPlum(ctx, w, h, PLUM_SEED)
 
     const av = 52
     ctx.save()
@@ -178,18 +185,16 @@ export function useHighlightCard() {
     ctx.fillText('Adebesin Tolulope', nameX, P + av / 2 + 1)
     const nameW = ctx.measureText('Adebesin Tolulope').width
     ctx.fillStyle = MUTED
-    ctx.font = 'italic 500 26px Newsreader, serif'
-    ctx.fillText('/ Blog', nameX + nameW + 12, P + av / 2 + 1)
+    ctx.font = '500 26px Inter, sans-serif'
+    ctx.fillText('(Lope)', nameX + nameW + 10, P + av / 2 + 1)
 
     ctx.textAlign = 'right'
-    ctx.fillStyle = FAINT
-    ctx.font = '500 14px "JetBrains Mono", monospace'
-    ctx.letterSpacing = '3px'
-    ctx.fillText('PULLED FROM THE POST', w - P, P + av / 2 + 1)
-    ctx.letterSpacing = '0px'
+    ctx.textBaseline = 'alphabetic'
+    ctx.fillStyle = MUTED
+    ctx.font = '700 46px Caveat, cursive'
+    ctx.fillText('at', w - P, P + 40)
     ctx.textAlign = 'left'
 
-    ctx.textBaseline = 'alphabetic'
     const markY = P + av + 74
     ctx.fillStyle = 'rgba(244,244,245,0.22)'
     ctx.font = '500 96px Newsreader, serif'
@@ -197,9 +202,8 @@ export function useHighlightCard() {
 
     const paras = data.quote.split('\n').map(s => s.trim()).filter(Boolean)
     const textTop = markY + 18
-    const footerTop = h - P - 46
-    const sigGap = 54
-    const availH = footerTop - sigGap - textTop
+    const footerBoundary = h - P - 78
+    const availH = footerBoundary - textTop
 
     const max = Math.round(w * 0.05)
     const min = Math.round(w * 0.015)
@@ -231,23 +235,45 @@ export function useHighlightCard() {
       y += lh
     }
 
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'alphabetic'
     ctx.fillStyle = INK
     ctx.font = '600 42px Caveat, cursive'
-    ctx.fillText('— Lope', P, footerTop - 6)
+    ctx.fillText('— Lope', P, h - P + 4)
 
-    ctx.textAlign = 'right'
-    if (data.title) {
-      ctx.fillStyle = MUTED
-      ctx.font = 'italic 400 19px Newsreader, serif'
-      const t = `from “${data.title}”`
-      ctx.fillText(ctx.measureText(t).width > contentW * 0.9 ? `${t.slice(0, 60)}…”` : t, w - P, footerTop + 8)
-    }
     if (data.url) {
       ctx.fillStyle = FAINT
       ctx.font = '400 14px "JetBrains Mono", monospace'
-      ctx.fillText(data.url.replace(/^https?:\/\//, ''), w - P, footerTop + 32)
+      ctx.fillText(data.url.replace(/^https?:\/\//, ''), P, h - P + 28)
     }
-    ctx.textAlign = 'left'
+
+    if (data.title) {
+      ctx.font = '500 20px Inter, sans-serif'
+      let label = data.title
+      const maxTw = contentW * 0.5
+      if (ctx.measureText(label).width > maxTw) {
+        while (label.length > 4 && ctx.measureText(`${label}…`).width > maxTw)
+          label = label.slice(0, -1)
+        label = `${label.trimEnd()}…`
+      }
+      const tw = ctx.measureText(label).width
+      const padX = 18
+      const pillH = 42
+      const pillW = tw + padX * 2
+      const pillX = w - P - pillW
+      const pillY = h - P - pillH + 6
+      ctx.beginPath()
+      ctx.roundRect(pillX, pillY, pillW, pillH, 8)
+      ctx.fillStyle = 'rgba(244,244,245,0.05)'
+      ctx.fill()
+      ctx.strokeStyle = 'rgba(244,244,245,0.12)'
+      ctx.lineWidth = 1
+      ctx.stroke()
+      ctx.fillStyle = INK
+      ctx.textBaseline = 'middle'
+      ctx.fillText(label, pillX + padX, pillY + pillH / 2 + 1)
+      ctx.textBaseline = 'alphabetic'
+    }
   }
 
   return { draw }

--- a/app/pages/blog/[...slug].vue
+++ b/app/pages/blog/[...slug].vue
@@ -120,7 +120,7 @@ function fmt(d?: string) {
 
     <ContentRenderer :value="post" class="prose-content" />
 
-    <HighlightShare :title="shareTitle" :url="postUrl" />
+    <HighlightShare :title="shareTitle" :url="postUrl" :date="post.date" />
 
     <ark.div class="mt-14 pt-6 border-t border-ink/10 flex items-center gap-4 text-sm text-ink-muted">
       <ark.span>Share</ark.span>


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #25.

### 🧭 Context

Make share card on brand

### 📚 Description

Every change maps to something the portfolio already does:

- **Dropped the corner-brackets and the mono tag** — the two elements that made it look borrowed.
- **Giant faint year watermark** behind the quote — the same `op-5` oversized-numeral move as the 404 status code and the blog-list year markers. It pulls the post's publish year.
- **Dot grid** across the card, matching `DotBackground`.
- **`Adebesin Tolulope (Lope)`** with `(Lope)` muted, copied from the homepage `<h1>`.
- **Handwritten `at` mark** (tegaki + Caveat) where the tag used to sit — the actual logo instead of a made-up label.
- **Source is a bordered chip** (`i-lucide-newspaper` + title), like every link on the homepage; the url sits under the `— Lope` signature.
- **Plum branches fill the whole card** — spawns from all four edges like `ArtPlum` does on the page, not just two, at a slightly lower opacity so the quote stays readable.

The preview (DOM) and the downloaded PNG (canvas) share one branch generator and mirror the same layout, so what you see is what you get.
